### PR TITLE
gptcache 0.1.43

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,26 @@
 {% set name = "gptcache" %}
-{% set version = "0.1.20" %}
+{% set version = "0.1.43" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/gptcache-{{ version }}.tar.gz
-  sha256: 4e2f858b0291573d7dd04007754936a7e5a7c80fae318d30f47f2de7791244d8
-  patches:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: cebe7ec5e32a3347bf839e933a34e67c7fcae620deaa7cb8c6d7d276c8686f1a
+  patches:                                   # [win]
     - patches/0001-read-file-as-utf8.patch   # [win]
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
-  # Minimum Python requirement is 3.8, and openai isn't available on s390x.
+  number: 0
+  # openai isn't available on s390x.
   skip: True # [py<38 or s390x]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - gptcache_server = gptcache_server.server:main
 
 requirements:
-  build:
+  build:               # [win]
     - m2-patch         # [win]
   host:
     - python
@@ -27,7 +29,12 @@ requirements:
     - setuptools
   run:
     - python
-    - openai
+    # openai isn't mentioned in requirements.txt
+    # but its import hardcoded as 'pip install openai==0.28.1' through import_openai()
+    # see https://github.com/zilliztech/GPTCache/blob/0.1.43/gptcache/embedding/openai.py#L8-L10
+    # because gptcache doesn't have support for openai >=1,
+    # see also https://github.com/zilliztech/GPTCache/issues/576
+    #- openai <1.0.0a1
     - numpy
     - requests
     - cachetools
@@ -35,10 +42,10 @@ requirements:
 test:
   imports:
     - gptcache
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://zilliz.com/what-is-gptcache
@@ -51,7 +58,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   dev_url: https://github.com/zilliztech/GPTCache
-  doc_url: https://github.com/zilliztech/GPTCache/tree/main/docs
+  doc_url: https://gptcache.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,8 @@ requirements:
     - numpy
     - requests
     - cachetools
+  run_constrained:
+    - openai <1.0.0a0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,16 +29,15 @@ requirements:
     - setuptools
   run:
     - python
+    - numpy
+    - requests
+    - cachetools
+  run_constrained:
     # openai isn't mentioned in requirements.txt
     # but its import hardcoded as 'pip install openai==0.28.1' through import_openai()
     # see https://github.com/zilliztech/GPTCache/blob/0.1.43/gptcache/embedding/openai.py#L8-L10
     # because gptcache doesn't have support for openai >=1,
     # see also https://github.com/zilliztech/GPTCache/issues/576
-    #- openai <1.0.0a1
-    - numpy
-    - requests
-    - cachetools
-  run_constrained:
     - openai <1.0.0a0
 
 test:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4656](https://anaconda.atlassian.net/browse/PKG-4656) 
- Requirements:  https://github.com/zilliztech/GPTCache/blob/0.1.43/requirements.txt

### Explanation of changes:

- Disable openai as it's **not** a [required](https://github.com/zilliztech/GPTCache/blob/0.1.43/requirements.txt) dependency. At the same time openai >=1.0.0 crashes because of incompatibility, see the comment in the meta.yaml


[PKG-4656]: https://anaconda.atlassian.net/browse/PKG-4656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ