### PR TITLE
gptcache 0.1.44 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,8 @@ test:
     - gptcache
   commands:
     - pip check
-    - gptcache_server --help
+    # Need extra access to install some deps with pip on Windows, like uvicorn, etc.
+    - gptcache_server --help  # [not win]
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,22 @@
 {% set name = "gptcache" %}
-{% set version = "0.1.43" %}
+{% set version = "0.1.44" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cebe7ec5e32a3347bf839e933a34e67c7fcae620deaa7cb8c6d7d276c8686f1a
+  sha256: d3d5e6a75c57594dc58212c2d6c53a7999c23ede30e0be66d213d885c0ad0be9
   patches:                                   # [win]
     - patches/0001-read-file-as-utf8.patch   # [win]
 
 build:
   number: 0
-  # openai isn't available on s390x.
-  skip: True # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - gptcache_server = gptcache_server.server:main
+  skip: True # [py<38]
 
 requirements:
   build:               # [win]
@@ -35,7 +34,7 @@ requirements:
   run_constrained:
     # openai isn't mentioned in requirements.txt
     # but its import hardcoded as 'pip install openai==0.28.1' through import_openai()
-    # see https://github.com/zilliztech/GPTCache/blob/0.1.43/gptcache/embedding/openai.py#L8-L10
+    # see https://github.com/zilliztech/GPTCache/blob/0.1.44/gptcache/embedding/openai.py#L8
     # because gptcache doesn't have support for openai >=1,
     # see also https://github.com/zilliztech/GPTCache/issues/576
     - openai <1.0.0a0
@@ -43,10 +42,11 @@ requirements:
 test:
   imports:
     - gptcache
-  requires:
-    - pip
   commands:
     - pip check
+    - gptcache_server --help
+  requires:
+    - pip
 
 about:
   home: https://zilliz.com/what-is-gptcache

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ about:
   description: |
     GPTCache is a powerful caching library that can be used to speed up and lower the cost of
     chat applications that rely on the LLM service. GPTCache works as a memcache for
-    AIGC applications, similar to how Redis works for traditional applications.
+    AIGC applications, similar to how Redis works for traditional applications
   license: MIT
   license_family: MIT
   license_file: LICENSE


### PR DESCRIPTION
gptcache 0.1.44 

**Destination channel:** Defaults

### Links

- [PKG-10744]
- dev_url:        https://github.com/zilliztech/GPTCache/tree/0.1.44
- conda_forge:    https://github.com/conda-forge/gptcache-feedstock
- pypi:           https://pypi.org/project/gptcache/0.1.44
- pypi inspector: https://inspector.pypi.io/project/gptcache/0.1.44

### Explanation of changes:

- new version number


[PKG-10744]: https://anaconda.atlassian.net/browse/PKG-10744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ